### PR TITLE
use gcr cadvisor instead of google/cadvisor

### DIFF
--- a/monitoring/cadvisor/Dockerfile
+++ b/monitoring/cadvisor/Dockerfile
@@ -1,1 +1,1 @@
-FROM google/cadvisor:latest
+FROM gcr.io/google-containers/cadvisor:latest


### PR DESCRIPTION
Because:
google/cadvisor is deprecated.
Ref: https://hub.docker.com/r/google/cadvisor/